### PR TITLE
From some version neo4j care about difference between empty list and map

### DIFF
--- a/PackStream/v1/Packer.php
+++ b/PackStream/v1/Packer.php
@@ -72,11 +72,13 @@ class Packer implements IPacker
             $output .= $this->packString($param);
         } elseif (is_array($param)) {
             $keys = array_keys($param);
-            if (count($keys) > 0 && count(array_filter($keys, 'is_int')) == count($keys)) {
+            if (count($param) == 0 || count(array_filter($keys, 'is_int')) == count($keys)) {
                 $output .= $this->packList($param);
             } else {
                 $output .= $this->packMap($param);
             }
+        } elseif (is_object($param)) {
+            $output .= $this->packMap((array)$param);
         } else {
             throw new Exception('Not recognized type of parameter');
         }

--- a/protocol/V3.php
+++ b/protocol/V3.php
@@ -66,7 +66,7 @@ class V3 extends V2
         }
 
         try {
-            $msg = $this->packer->pack(0x10, $args[0], $args[1] ?? [], $args[2] ?? []);
+            $msg = $this->packer->pack(0x10, $args[0], (object)($args[1] ?? []), (object)($args[2] ?? []));
         } catch (Exception $ex) {
             Bolt::error($ex->getMessage());
             return false;
@@ -97,7 +97,7 @@ class V3 extends V2
     public function begin(...$args): bool
     {
         try {
-            $msg = $this->packer->pack(0x11, $args[0] ?? []);
+            $msg = $this->packer->pack(0x11, (object)($args[0] ?? []));
         } catch (Exception $ex) {
             Bolt::error($ex->getMessage());
             return false;

--- a/protocol/V4.php
+++ b/protocol/V4.php
@@ -28,7 +28,7 @@ class V4 extends V3
         }
 
         try {
-            $msg = $this->packer->pack(0x3F, $args[0] ?? []);
+            $msg = $this->packer->pack(0x3F, (object)($args[0] ?? []));
         } catch (Exception $ex) {
             Bolt::error($ex->getMessage());
             return false;

--- a/protocol/V4_1.php
+++ b/protocol/V4_1.php
@@ -29,7 +29,7 @@ class V4_1 extends V4
                 'scheme' => $args[1],
                 'principal' => $args[2],
                 'credentials' => $args[3],
-                'routing' => $args[4] ?? []
+                'routing' => (object)($args[4] ?? [])
             ]);
         } catch (Exception $ex) {
             Bolt::error($ex->getMessage());


### PR DESCRIPTION
- Internally handled it with using stdClass
- Now also parameter can be class, which is always packed as map (ex. ```(class)['a' => 123]```)
- Original logic with auto decisioning list/map keeped. Array with all int keys is list, otherwise map.