### PR TITLE
Updated fread() function to stream_get_contents() to resolve timemout…

### DIFF
--- a/src/connection/StreamSocket.php
+++ b/src/connection/StreamSocket.php
@@ -92,7 +92,7 @@ class StreamSocket extends AConnection
      */
     public function read(int $length = 2048): string
     {
-        $res = fread($this->stream, $length);
+        $res = stream_get_contents($this->stream, $length);
         if (empty($res))
             throw new ConnectException('Read error');
 


### PR DESCRIPTION
Full error prior to this fix:

PHP Fatal error:  Uncaught Bolt\error\ConnectException: Read error in /web-root/vendor/stefanak-michal/bolt/src/connection/StreamSocket.php:97
Stack trace:
#0 /web-root/vendor/stefanak-michal/bolt/src/protocol/AProtocol.php(93): Bolt\connection\StreamSocket->read()
#1 /web-root/vendor/stefanak-michal/bolt/src/protocol/V4.php(39): Bolt\protocol\AProtocol->read()
#2 /web-root/vendor/stefanak-michal/bolt/src/protocol/V4.php(25): Bolt\protocol\V4->pull()
#3 /web-root/vendor/stefanak-michal/bolt/src/Bolt.php(274): Bolt\protocol\V4->pullAll()
#4 /web-root/vendor/laudis/neo4j-php-client/src/Network/Bolt/BoltSession.php(130): Bolt\Bolt->pullAll()
#5 /web-root/vendor/laudis/neo4j-php-client/src/Network/Bolt/BoltSession.php(57): Laudis\Neo4j\Network\Bolt\BoltSession->runStatements()
#6 /web-root/vendor/laudis/neo4j-php-client/src/Client.php(54): Laudis\Neo4j\Network\Bolt\BoltSession->run()
#7 /web-root/vendor/laudis/neo4j-php-client/src/Client.php(46): Laudis\Neo4j\Client->r in /web-root/vendor/laudis/neo4j-php-client/src/Network/Bolt/BoltSession.php on line 132